### PR TITLE
Factual error: 6-01-computations-v8.Rmd

### DIFF
--- a/6-01-computations-v8.Rmd
+++ b/6-01-computations-v8.Rmd
@@ -35,11 +35,9 @@ install.packages("V8")
 
 ## Basics {#v8-basics}
 
-V8 provides a reference class provided via the [R6](https://github.com/r-lib/R6) [@R-R6] package; this pertains to object-oriented programming; hence it might look unconventional to many R users. It's nonetheless easy to grasp. If one wants to learn more about the R6's reference class system, Hadley Wickham has an outstanding chapter on it in his [Advanced R](https://adv-r.hadley.nz/r6.html) book.
+V8 provides an JavaScript execution environment through returning a closure-based object with `v8()`; Each of such environments is independent of another. 
 
-Let us explore the basic functionalities of the package. First, load the library and use the function `v8` to instantiate a class; this effectively returns an execution environment, every such environment is independent of another.
-
-```{r v8-baisc-load}
+```{r v8-basic-load}
 library(V8)
 
 engine <- v8()


### PR DESCRIPTION
V8 does not depend on R6, but instead instantiates an object through capturing and returning the closure of `v8()` itself. This construction is commonly seen in code written in JS itself, which may have caused the author to employ such. 
Removed languages referring to R6.  
Verify with: 
```r
packageVersion("V8")
tools::package_dependencies("V8")
```