### PR TITLE
htmlwidgets custom html modified

### DIFF
--- a/3-23-htmlwidgets-peity.Rmd
+++ b/3-23-htmlwidgets-peity.Rmd
@@ -340,7 +340,7 @@ As pointed out multiple times, the widget is generated in a `<div>`, which is wo
 This can be changed by placing a function named `widgetname_html`, which is looked up by htmlwidgets and used if found. This is probably the first such function one encounters and is relatively uncommon, but it is literally how the htmlwidgets\index{htmlwidgets} package does it: it scans the namespace of the package looking for a function that starts with the name of the widget and ends in `_html` and if found uses it. Otherwise, it uses the default `div`. This function takes the three-dot construct (`...`) and uses them in an htmltools tag. The three-dots are necessary because internally htmlwidgets need to be able to pass the `id`, `class`, and `style` attributes to the tag.
 
 ```r
-peity_html <- function(...){
+widget_html.peity <- function(...) {
   htmltools::tags$span(...)
 }
 ```
@@ -348,8 +348,8 @@ peity_html <- function(...){
 This can also come in handy if some arguments must be hard-coded, such as assigning a specific class to every widget.
 
 ```r
-myWidget_html <- function(..., class){
-  htmltools::tags$div(..., class = c(class, "my-class"))
+widget_html.myWidget <- function(..., class){
+  htmltools::tags$div(..., class = paste(class,"my-class"))
 }
 ```
 


### PR DESCRIPTION
hello,
Thank you for your book, It's very good!
When I use Rmd to test my htmlwidgets when I use htmlwidgets, it doesn’t seem to work when I use PACKAGE:::NAME_html. I changed it to PACKAGE:::widget_html.NAME. [ref link](https://github.com/ramnathv/htmlwidgets/blob/707c9b11d103b25819badc5f49a823378e4a3c15/R/htmlwidgets.R#L241-L249)
When using htmltools::tags$div(..., class = c(class,"my-class")), the following error was reported.
```R
Error in writeImpl(text) : 
  Text to be written must be a length-one character vector
In addition: Warning message:
In if (!is.na(attribValue)) { :
  the condition has length > 1 and only the first element will be used
```

<details><summary>session_Info()</summary>

```R
─ Session info ──────────────────────────────────────────────────
 setting  value                       
 version  R version 4.1.0 (2021-05-18)
 os       Ubuntu 20.04.2 LTS          
 system   x86_64, linux-gnu           
 ui       RStudio                     
 language (EN)                        
 collate  en_US.UTF-8                 
 ctype    en_US.UTF-8                 
 tz       Etc/UTC                     
 date     2021-07-30                  

─ Packages ──────────────────────────────────────────────────────
 ! package     * version date       lib source        
   htmltools   * 0.5.1.1 2021-01-22 [1] RSPM (R 4.1.0)
   htmlwidgets * 1.5.3   2020-12-10 [1] CRAN (R 4.1.0)
```

</p>
</details>