### PR TITLE
Use up-to-date NPM package name for countUp.js

### DIFF
--- a/7-04-webpack-advanced.Rmd
+++ b/7-04-webpack-advanced.Rmd
@@ -112,10 +112,10 @@ const asHeader = (x) => {
 export { asHeader };
 ```
 
-We will make changes to the JavaScript so that instead of displaying the message as text, it uses the aforementioned countup library to animate a number. The first order of business is to install countup. Here we use packer to do so; the function call below is identical to running `npm install countup --save` from the terminal.
+We will make changes to the JavaScript so that instead of displaying the message as text, it uses the aforementioned countup library to animate a number. The first order of business is to install countup. Here we use packer to do so; the function call below is identical to running `npm install countup.js --save` from the terminal.
 
 ```r
-packer::npm_install("countup", scope = "prod") 
+packer::npm_install("countup.js", scope = "prod") 
 ```
 
 We will not need the `header.js` file. We can delete it and in its stead create another file called `count.js`. This file will include a function that uses countup to animate the numbers. It should accept 1) the id of the element where countup should be used, and 2) the value that countup should animate. This function called `counter` is, at the end of the file, exported\index{export}.


### PR DESCRIPTION
I was trying to follow the examples in Chapter 23 and had some strange results. Installing `countup.js` instead of `countup` fixed them for me.